### PR TITLE
サイドバーのメッセージの表示機能の実装

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :members
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,22 +1,5 @@
 .side
-  .side__header
-    %h3.side__header--user
-      = current_user.name
-    .side__header--account
-      = link_to edit_user_path(current_user) do
-        = fa_icon 'cog'
-    .side__header--new
-      = link_to new_group_path do
-        = fa_icon 'edit'
-
-  .side__body
-    .side__body--group
-      - current_user.groups.each do |group|
-        = link_to group_messages_path(group) do
-          .side__body--group__name
-            = group.name
-          .side__body--message
-            top-message
+  = render 'shared/side_bar'
 
 .main
   .main__header

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -16,4 +16,4 @@
           .side__body--group__name
             = group.name
           .side__body--message
-            top-message
+            = group.show_last_message


### PR DESCRIPTION
# What
サイドバーの各グループの最新のメッセージを表示する。
# Why
メッセージが更新されていることの確認を容易にするため。